### PR TITLE
Fixed :dev-dependencies documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For a list of pallet tasks,
 
 Add the plugin to your `project.clj` file.
 
-    :dev-dependencies [[pallet-lein "0.2.0"]]
+    :dev-dependencies [[org.cloudhoist/pallet-lein "0.2.0"]]
 
 ## License
 


### PR DESCRIPTION
Fixed :dev-dependencies documentation for project.clj.
