### PR TITLE
Fix pallet 8 dependency mismatch.

### DIFF
--- a/src/leiningen/pallet.clj
+++ b/src/leiningen/pallet.clj
@@ -20,7 +20,7 @@
 (defn pallet-profile [{:keys [pallet] :as project}]
   {:source-paths (:source-paths pallet ["pallet/src"])
    :resource-paths (:resource-paths pallet ["pallet/resources"])
-   :dependencies '[^:displace [com.palletops/pallet "0.8.0-beta.6"]
+   :dependencies '[^:displace [com.palletops/pallet "0.8.0-SNAPSHOT"]
                    ^:displace [org.cloudhoist/pallet-vmfest "0.3.0-alpha.2"]
                    ^:displace [org.clojars.tbatchelli/vboxjxpcom "4.2.4"]
                    ;; [org.clojars.tbatchelli/vboxjws "4.2.4"]


### PR DESCRIPTION
profile.clj stated the dependency as 0.8.0-SNAPSHOT but the dynamically created profile was bringing a previous version of pallet (beta.6)
